### PR TITLE
Add 'docker run' to redis build.sh to start redis container after build.

### DIFF
--- a/redis/build.sh
+++ b/redis/build.sh
@@ -7,3 +7,10 @@ done < ../etc/nextcloud.config
 
 docker build \
   --no-cache -t redis .
+
+docker run -\
+  d \
+  --name redis \
+  -h redis \
+  --network=nextcloud \
+  redis


### PR DESCRIPTION
Add 'docker run' to redis build.sh to start redis container after build.