### PR TITLE
Update MariaDB to 10.6.

### DIFF
--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -11,6 +11,11 @@ RUN wget -O /etc/pki/rpm-gpg/MariaDB-Server-GPG-KEY https://downloads.mariadb.co
 # Copy over MariaDB repo file.
 COPY mariadb.repo /etc/yum.repos.d/
 
+# Setup mysql user.
+RUN export uid=27 gid=27 && \
+  echo "mysql:x:${uid}:${gid}:MariaDB Server:/var/lib/mysql:/sbin/nologin" >> /etc/passwd && \
+  echo "mysql:x:${uid}:" >> /etc/group
+
 # Install MariaDB.
 RUN yum install -y \
   MariaDB-client \
@@ -18,10 +23,5 @@ RUN yum install -y \
 
 # Copy over Nextcloud-specific MySQL requirements.
 COPY nextcloud.cnf /etc/my.cnf.d
-
-# Setup mysql user.
-RUN export uid=27 gid=27 && \
-  echo "mysql:x:${uid}:${gid}:MariaDB Server:/var/lib/mysql:/sbin/nologin" >> /etc/passwd && \
-  echo "mysql:x:${uid}:" >> /etc/group
 
 CMD /usr/bin/mysqld_safe

--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -3,8 +3,18 @@ FROM centos:7
 # Update and install some useful packages.
 RUN yum update -y && \
   yum install -y \
-    mariadb \
-    mariadb-server
+    wget
+
+# Retrieve MariaDB repo GPG key.
+RUN wget https://downloads.mariadb.com/MariaDB/MariaDB-Server-GPG-KEY > /etc/pki/rpm-gpg/MariaDB-Server-GPG-KEY
+
+# Copy over MariaDB repo file.
+COPY mariadb.repo /etc/yum.repos.d/
+
+# Install MariaDB.
+RUN yum install -y \
+  MariaDB-client \
+  MariaDB-server
 
 # Copy over Nextcloud-specific MySQL requirements.
 COPY nextcloud.cnf /etc/my.cnf.d

--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -6,7 +6,7 @@ RUN yum update -y && \
     wget
 
 # Retrieve MariaDB repo GPG key.
-RUN wget https://downloads.mariadb.com/MariaDB/MariaDB-Server-GPG-KEY > /etc/pki/rpm-gpg/MariaDB-Server-GPG-KEY
+RUN wget -O /etc/pki/rpm-gpg/MariaDB-Server-GPG-KEY https://downloads.mariadb.com/MariaDB/MariaDB-Server-GPG-KEY
 
 # Copy over MariaDB repo file.
 COPY mariadb.repo /etc/yum.repos.d/

--- a/mysql/mariadb.repo
+++ b/mysql/mariadb.repo
@@ -1,0 +1,8 @@
+# Derived from mariadb_repo_setup.  See
+# https://mariadb.com/resources/blog/installing-mariadb-10-on-centos-7-rhel-7/
+[mariadb-main]
+name = MariaDB Server
+baseurl = https://dlm.mariadb.com/repo/mariadb-server/10.6/yum/rhel/7/x86_64
+gpgkey = file:///etc/pki/rpm-gpg/MariaDB-Server-GPG-KEY
+gpgcheck = 1
+enabled = 1

--- a/mysql/nextcloud.cnf
+++ b/mysql/nextcloud.cnf
@@ -2,3 +2,4 @@
 innodb_large_prefix=true
 innodb_file_format=barracuda
 innodb_file_per_table=1
+innodb-read-only-compressed=OFF


### PR DESCRIPTION
Update MariaDB to 10.6.

* NextCloud 21+ requires MariaDB 10+.
* MariaDB 10.6 begins the process of removing support for `ROW_FORMAT=COMPRESSED`, thus requiring `innodb-read-only-compressed=OFF` be added to `nextcloud.cnf`.  See https://github.com/nextcloud/server/issues/25436 for details.